### PR TITLE
Change sidebar submenu text alignment to center

### DIFF
--- a/embed_grader/serapis/static/serapis/sidebar.css
+++ b/embed_grader/serapis/static/serapis/sidebar.css
@@ -124,7 +124,7 @@ Licensed under MIT
 #submenu1 a {
   background-color: #f6f9fb;
   font-size: 13px;
-  text-align: right;
+  text-align: center;
 }
 
 #submenu1 a:hover {


### PR DESCRIPTION
Partially and temporarily fix #104. As we will change the organization of sidebar eventually. This PR merely changes the text alignment to `center`.