### PR TITLE
Make visualizer_manager more template friendly

### DIFF
--- a/embed_grader/serapis/templates/serapis/task_grading_detail.html
+++ b/embed_grader/serapis/templates/serapis/task_grading_detail.html
@@ -14,15 +14,11 @@
 {% block submissions-active %}active{% endblock %}
 
 {% block page-specific-css %}
-  {% for css in css_files %}
-    <link rel="stylesheet" href="{{css}}" type="text/css" media="all" />
-  {% endfor %}
+  {{ visualizer_manager.render_css }}
 {% endblock %}
 
 {% block page-specific-js %}
-  {% for js in js_files %}
-    <script src={{js}}></script>
-  {% endfor %}
+  {{ visualizer_manager.render_js }}
 {% endblock %}
 
 {% block main-content %}
@@ -50,7 +46,7 @@
     <h4>Grading feedback:<h4>
     <p style="white-space:pre; font-size:13px; font-family:monospace">{{feedback}}</p>
 
-    {% for visualization in output_visualizations %}
+    {% for visualization in visualizer_manager.get_visualizations %}
       <hr/>
       <h4>File: {{visualization.field_name}}
         <a href="{{ MEDIA_URL }}{{ visualization.url }}" class="btn btn-primary btn-detail-enabled">
@@ -59,7 +55,6 @@
       </h4>
       <br/>
       {{ visualization.html }}
-      <p style="white-space:pre; font-size:13px; font-family:monospace">{{output.content}}</p>
     {% endfor %}
 
   </div>

--- a/embed_grader/serapis/templates/serapis/view_task_input.html
+++ b/embed_grader/serapis/templates/serapis/view_task_input.html
@@ -14,15 +14,11 @@
 {% block courses-active %}active{% endblock %}
 
 {% block page-specific-css %}
-  {% for css in css_files %}
-    <link rel="stylesheet" href="{{css}}" type="text/css" media="all" />
-  {% endfor %}
+  {{ visualizer_manager.render_css }}
 {% endblock %}
 
 {% block page-specific-js %}
-  {% for js in js_files %}
-    <script src={{js}}></script>
-  {% endfor %}
+  {{ visualizer_manager.render_js }}
 {% endblock %}
 
 {% block main-content %}
@@ -47,7 +43,7 @@
 
     <h3 class="page-header">Input Files</h3>
 
-    {% for visualization in input_visualizations %}
+    {% for visualization in visualizer_manager.get_visualizations %}
       <h4>File: {{visualization.field_name}}
         <a href="{{ MEDIA_URL }}{{ visualization.url }}" class="btn btn-primary btn-detail-enabled">
           <span class="glyphicon glyphicon-download-alt"></span> &nbsp;Download
@@ -55,7 +51,6 @@
       </h4>
       <br/>
       {{ visualization.html }}
-      <p style="white-space:pre; font-size:13px; font-family:monospace">{{output.content}}</p>
     {% endfor %}
   </div>
 {% endblock %}

--- a/embed_grader/serapis/templates/serapis/visualizers/visualizer_manager/render_css.html
+++ b/embed_grader/serapis/templates/serapis/visualizers/visualizer_manager/render_css.html
@@ -1,0 +1,3 @@
+{% for css in css_files %}
+  <link rel="stylesheet" href="{{css}}" type="text/css" media="all" />
+{% endfor %}

--- a/embed_grader/serapis/templates/serapis/visualizers/visualizer_manager/render_js.html
+++ b/embed_grader/serapis/templates/serapis/visualizers/visualizer_manager/render_js.html
@@ -1,0 +1,3 @@
+{% for js in js_files %}
+  <script src={{js}}></script>
+{% endfor %}

--- a/embed_grader/serapis/utils/visualizer_manager.py
+++ b/embed_grader/serapis/utils/visualizer_manager.py
@@ -1,3 +1,7 @@
+from django.template.loader import get_template
+from django.template import Context
+
+
 class VisualizerManager(object):
 
     def __init__(self):
@@ -16,21 +20,25 @@ class VisualizerManager(object):
             'url': url,
         })
 
-    def get_js_files(self):
+    def render_js(self):
         """
-        Return a list indicating all the javascript files that the visualizers request. Note
-        the list preserves the order that each visualizer requests
+        Return a list of <script> tags in html format. These tags are for importing the javascript
+        files that the visualizers request. Note the list preserves the order that each visualizer
+        requests.
         """
-        return self.js_files
+        template = get_template('serapis/visualizers/visualizer_manager/render_js.html')
+        return template.render(Context({'js_files': self.js_files}))
 
-    def get_css_files(self):
+    def render_css(self):
         """
-        Return a list indicating all the css files that the visualizers request. Note the list
-        preserves the order that each visualizer requests
+        Return a list of <link> tags in html format. These tags are for importing the css files
+        that the visualizers request. Note the list preserves the order that each visualizer
+        requests.
         """
-        return self.css_files
+        template = get_template('serapis/visualizers/visualizer_manager/render_css.html')
+        return template.render(Context({'css_files': self.css_files}))
 
-    def get_visualizations_for_template(self):
+    def get_visualizations(self):
         """
         Return a list of dictionaries, which always include 'field_name', 'html', and 'url'
         """

--- a/embed_grader/serapis/views/submissions.py
+++ b/embed_grader/serapis/views/submissions.py
@@ -130,9 +130,6 @@ def task_grading_detail(request, task_grading_id):
         raw_content = file.read()
         url = file.url
         visualizer_manager.add_file(field_name, raw_content, url)
-    js_files = visualizer_manager.get_js_files()
-    css_files = visualizer_manager.get_css_files()
-    output_visualizations = visualizer_manager.get_visualizations_for_template()
 
     if task_grading_status.grading_detail:
         feedback = task_grading_status.grading_detail.read()
@@ -148,9 +145,7 @@ def task_grading_detail(request, task_grading_id):
         'team_member_names': team_member_names,
         'grading': task_grading_status,
         'assignment_task': assignment_task,
-        'js_files': js_files,
-        'css_files': css_files,
-        'output_visualizations': output_visualizations,
+        'visualizer_manager': visualizer_manager,
         'feedback': feedback,
     }
 

--- a/embed_grader/serapis/views/tasks.py
+++ b/embed_grader/serapis/views/tasks.py
@@ -181,17 +181,11 @@ def view_task_input_files(request, task_id):
         url = file.url
         visualizer_manager.add_file(field_name, raw_content, url)
 
-    js_files = visualizer_manager.get_js_files()
-    css_files = visualizer_manager.get_css_files()
-    input_visualizations = visualizer_manager.get_visualizations_for_template()
-
     template_context = {
             'myuser': request.user,
             'course': course,
             'assignment': assignment,
             'task': task,
-            'js_files': js_files,
-            'css_files': css_files,
-            'input_visualizations': input_visualizations,
+            'visualizer_manager': visualizer_manager,
     }
     return render(request, 'serapis/view_task_input.html', template_context)


### PR DESCRIPTION
we only need to pass visualizer_manager to the template instead of separating into js_files, css_files, and visualizations