### PR TITLE
change query filters so only courses from current quarter shows up

### DIFF
--- a/embed_grader/serapis/forms/course_forms.py
+++ b/embed_grader/serapis/forms/course_forms.py
@@ -128,8 +128,7 @@ class CourseEnrollmentForm(Form):
         cur_year = now.year
         cur_month = now.month
         cur_quarter = (cur_month - 1) // 3
-        cur_year_quarter = cur_year * 4 + cur_quarter
-
+        
         self.fields['course_select'] = forms.ModelChoiceField(
             queryset=Course.objects.filter(year=cur_year, quarter=cur_quarter))
 


### PR DESCRIPTION
The change was tested by creating a course in Winter 2018 and a course in Summer 2018, and then attempting to enroll. In the dropdown, only the Winter 2018 course appeared.